### PR TITLE
Add ability to have Inline Help Text generated in markdown from the Salesforce Field metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ apexdocs changelog --previousVersionDir force-app-previous --currentVersionDir f
 | `--customObjectsGroupName` | N/A   | The name under which custom objects will be grouped in the Reference Guide                                                                                                                               | `Custom Objects` | No       |
 | `--triggersGroupName`      | N/A   | The name under which triggers will be grouped in the Reference Guide                                                                                                                                     | `Triggers`       | No       |
 | `--includeFieldSecurityMetadata`      | N/A   | Whether to include the compliance category and security classification for fields in the generated files.                                                                                                                                     | `false`       | No       |
+| `--includeInlineHelpTextMetadata`      | N/A   | Whether to include the inline help text for fields in the generated files.                                                                                                                                     | `false`       | No       |
 
 ##### Linking Strategy
 

--- a/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
+++ b/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
@@ -3,6 +3,7 @@
     <fullName>Social_Security_Number__c</fullName>
     <externalId>false</externalId>
     <label>Social Security Number</label>
+    <inlineHelpText>You indicated the approval for storage of your social security number.</inlineHelpText>
     <description>Used to store the U.S. social security number in 9 digit format.</description>
     <length>9</length>
     <trackTrending>false</trackTrending>

--- a/src/cli/commands/markdown.ts
+++ b/src/cli/commands/markdown.ts
@@ -76,5 +76,9 @@ export const markdownOptions: Record<keyof CliConfigurableMarkdownConfig, Option
     type: 'boolean',
     describe: 'Whether to include the compliance category and security classification for fields in the generated files.',
     default: markdownDefaults.includeFieldSecurityMetadata,
-  }
+  },
+  includeInlineHelpTextMetadata: {
+    type: 'boolean',
+    describe: 'Whether to include the inline help text for fields in the generated files.',
+  },
 };

--- a/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
+++ b/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
@@ -25,6 +25,7 @@ export default class CustomFieldMetadataBuilder {
       required: false,
       securityClassification: 'Internal',
       complianceGroup: 'PII',
+      inlineHelpText: 'An image in either one of the following formats: JPEG, SVG, or PNG. For best results the image should be under 1MB in size.',
     };
   }
 }

--- a/src/core/markdown/__test__/test-helpers.ts
+++ b/src/core/markdown/__test__/test-helpers.ts
@@ -57,6 +57,7 @@ export function generateDocs(bundles: UnparsedSourceBundle[], config?: Partial<M
     excludeTags: [],
     referenceGuideTitle: 'Apex Reference Guide',
     includeFieldSecurityMetadata: true,
+    includeInlineHelpTextMetadata: true,
     exclude: [],
     ...config,
   });

--- a/src/core/markdown/adapters/__tests__/interface-adapter.spec.ts
+++ b/src/core/markdown/adapters/__tests__/interface-adapter.spec.ts
@@ -21,6 +21,7 @@ const defaultMarkdownGeneratorConfig: MarkdownGeneratorConfig = {
   linkingStrategy: 'relative',
   referenceGuideTitle: 'Apex Reference Guide',
   includeFieldSecurityMetadata: true,
+  includeInlineHelpTextMetadata: true,
   exclude: [],
   excludeTags: [],
 };

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -359,6 +359,7 @@ function fieldMetadataToRenderable(
     required: field.required,
     complianceGroup: renderComplianceGroup(field.complianceGroup, config),
     securityClassification: renderComplianceGroup(field.securityClassification, config),
+    inlineHelpText: renderInlineHelpText(field.inlineHelpText, config),
     pickListValues: field.pickListValues
       ? {
           headingLevel: headingLevel + 1,
@@ -401,3 +402,11 @@ function renderComplianceGroup(complianceGroup: string | null, config: MarkdownG
     return null;
   }
 }
+function renderInlineHelpText(inlineHelpText: string | null, config: MarkdownGeneratorConfig) {
+  if(config.includeInlineHelpTextMetadata) {
+    return inlineHelpText
+  } else {
+    return null;
+  }
+}
+

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -24,6 +24,11 @@ export const customObjectTemplate = `
 {{{renderContent description}}}
 {{/if}}
 
+{{#if inlineHelpText}}
+**Inline Help Text**
+{{inlineHelpText}}
+{{/if}}
+
 {{#if complianceGroup}}
 **Compliance Group**
 {{complianceGroup}}

--- a/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
@@ -16,6 +16,7 @@ const customFieldContent = `
     <description>A Photo URL field</description>
     <securityClassification>Internal</securityClassification>
     <complianceGroup>PII</complianceGroup>
+    <inlineHelpText>An image in either one of the following formats: JPEG, SVG, or PNG. For best results the image should be under 1MB in size.</inlineHelpText>
 </CustomField>`;
 
 describe('when parsing custom field metadata', () => {
@@ -135,6 +136,20 @@ describe('when parsing custom field metadata', () => {
     const result = await reflectCustomFieldSources([unparsed])();
 
     assertEither(result, (data) => expect(data[0].type.complianceGroup).toBe('PII'));
+  });
+
+  test('the resulting type contains the correct inline help text', async () => {
+    const unparsed: UnparsedCustomFieldBundle = {
+      type: 'customfield',
+      name: 'PhotoUrl__c',
+      parentName: 'MyFirstObject__c',
+      filePath: 'src/field/PhotoUrl__c.field-meta.xml',
+      content: customFieldContent,
+    };
+
+    const result = await reflectCustomFieldSources([unparsed])();
+
+    assertEither(result, (data) => expect(data[0].type.inlineHelpText).toBe('An image in either one of the following formats: JPEG, SVG, or PNG. For best results the image should be under 1MB in size.'));
   });
 
   test('can parse picklist values when there are multiple picklist values available', async () => {

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -20,6 +20,7 @@ export type CustomFieldMetadata = {
   required: boolean;
   securityClassification: string | null;
   complianceGroup: string | null;
+  inlineHelpText: string | null;
 };
 
 export function reflectCustomFieldSources(
@@ -70,6 +71,7 @@ function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFi
     required: false,
     securityClassification: null,
     complianceGroup: null,
+    inlineHelpText: null,
   };
 
   return {

--- a/src/core/reflection/sobject/reflect-custom-object-sources.ts
+++ b/src/core/reflection/sobject/reflect-custom-object-sources.ts
@@ -111,6 +111,7 @@ function convertInlineFieldsToCustomFieldMetadata(
   const required = inlineField.required ? (inlineField.required as boolean) : false;
   const securityClassification = inlineField.securityClassification ? (inlineField.securityClassification as string) : null;
   const complianceGroup = inlineField.complianceGroup ? (inlineField.complianceGroup as string) : null;
+  const inlineHelpText = inlineField.inlineHelpText ? (inlineField.inlineHelpText as string) : null;
 
   return {
     type_name: 'customfield',
@@ -122,6 +123,7 @@ function convertInlineFieldsToCustomFieldMetadata(
     required,
     securityClassification,
     complianceGroup,
+    inlineHelpText,
     pickListValues: getPickListValues(inlineField),
   };
 }

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -204,6 +204,7 @@ export type RenderableCustomField = {
   required: boolean;
   complianceGroup: string | null;
   securityClassification: string | null;
+  inlineHelpText: string | null;
 };
 
 export type RenderableCustomMetadata = {

--- a/src/core/shared/types.d.ts
+++ b/src/core/shared/types.d.ts
@@ -39,6 +39,7 @@ export type CliConfigurableMarkdownConfig = {
   linkingStrategy: LinkingStrategy;
   referenceGuideTitle: string;
   includeFieldSecurityMetadata: boolean;
+  includeInlineHelpTextMetadata: boolean;
 };
 
 export type UserDefinedMarkdownConfig = {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -20,6 +20,7 @@ export const markdownDefaults = {
   referenceGuideTitle: 'Reference Guide',
   excludeTags: [],
   includeFieldSecurityMetadata: false,
+  includeInlineHelpTextMetadata: false,
 };
 
 export const openApiDefaults = {


### PR DESCRIPTION
Use the includeInlineHelpText flag to indicate whether or not to output the value from the custom field metadata for the XML element, inlineHelpText. Update the readme to include usage details of the new flag including the default and parameter type.